### PR TITLE
Update project license to BSL 1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+Business Source License 1.1
+
+Licensor: NullNet AI
+
+Licensed Work: This repository and all source code, documentation, and related files.
+
+Additional Use Grant:
+
+You may use, copy, modify, compile, and deploy the Licensed Work for personal use, research, education, evaluation, testing, and internal business operations.
+
+You may not use the Licensed Work to provide a hosted service, managed service, cloud service, network service, security service, commercial SaaS product, resale product, OEM product, or competing commercial offering without prior written permission from NullNet AI.
+
+For clarity, internal use by a company is allowed. Offering the Licensed Work, modified versions, or substantially similar functionality to third parties as a paid or unpaid service is not allowed.
+
+Change Date: Four years from the date this license is first applied to this repository.
+
+Change License: Apache License 2.0

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+NullNet AI
+
+Copyright 2026 NullNet AI.
+
+This software is source available under the Business Source License 1.1.
+
+Commercial hosting, managed services, cloud services, resale, OEM use, and competing commercial offerings require prior written permission from NullNet AI.


### PR DESCRIPTION
Updates the project license to Business Source License 1.1 with an additional use grant allowing internal use while restricting hosted services, resale, OEM use, and competing commercial offerings.